### PR TITLE
Add DTBO to allow enabling UART1

### DIFF
--- a/patch/kernel/archive/rockchip64-6.6/overlay/Makefile
+++ b/patch/kernel/archive/rockchip64-6.6/overlay/Makefile
@@ -42,7 +42,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3568-hk-spi-spidev.dtbo \
 	rockchip-rk3568-hk-uart0.dtbo \
 	rockchip-rk3568-hk-uart0-rts_cts.dtbo \
-	rockchip-rk3568-hk-uart1.dtbo
+	rockchip-rk3568-hk-uart1.dtbo \
+	rockchip-mkspi-uart1.dtbo
 
 scr-$(CONFIG_ARCH_ROCKCHIP) += \
        rockchip-fixup.scr

--- a/patch/kernel/archive/rockchip64-6.6/overlay/rockchip-mkspi-uart1.dts
+++ b/patch/kernel/archive/rockchip64-6.6/overlay/rockchip-mkspi-uart1.dts
@@ -1,0 +1,30 @@
+/dts-v1/;
+
+/ {
+	compatible = "rockchip,rk3328";
+
+	fragment@0 {
+	target-path = "/spi@ff190000";
+
+		__overlay__ {
+			spi_for_lcd@0 {
+				status = "disabled";
+			};
+			spi_for_touch@1 {
+				status = "disabled";
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <0xffffffff>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	__fixups__ {
+		uart1 = "/fragment@1:target:0";
+	};
+};


### PR DESCRIPTION
# Description
Added a new dtb overlay to enable UART1 on the MKS Pi. The existing `rockchip-rk3328-uart1.dtbo` allows for registering UART1, but no connections on it work. The new overlay includes the contents of the generic rk3328 version, but also disables `spi_for_lcd` and `spi_for_touch` because their pinctrl definitions conflict with `uart1`. 

I don't know of any other MKS Pi based devices that actually use UART1, but this should work for any that need it.
 
# How Has This Been Tested?
This has been tested on the QIDI X_7 v1.0, the motherboard in the QIDI Q1 Pro 3D Printer. The TJC display on the printer uses UART1 rather than SPI0, and does not function without this overlay enabled. 

To use it, add `overlays=mkspi-uart1` to the end of `/boot/armbianEnv.txt`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
